### PR TITLE
Limit sink fill depth to one meter

### DIFF
--- a/Complete_Watershed.py
+++ b/Complete_Watershed.py
@@ -50,7 +50,7 @@ try:
     fill = lidar + "_fill"
     fill = AutoName(fill)
     outfill = fill
-    fill = arcpy.sa.Fill(lidar)
+    fill = arcpy.sa.Fill(lidar, 1)
 
     message = "Saving filled DEM as " + outfill + "..."
     arcpy.AddMessage(message)


### PR DESCRIPTION
Limiting sink fill depth prevents unrealistic catchment delineations.